### PR TITLE
added nav component

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -1,0 +1,47 @@
+//get end of url to decide whether to display "home" on menu
+const url = window.location.href;
+const lastSegment = url.split("/").pop();
+
+// Mobile Nav Opener only loads after html has parsed else "navOpener" doesn't exist
+document.addEventListener('DOMContentLoaded', (event) => {
+  const navOpener = document.querySelector('.nav-opener')
+  const nav = document.querySelector('nav')
+  
+  navOpener.addEventListener('click', () => {
+      nav.classList.toggle('nav-open');
+      navOpener.classList.toggle('exit')
+  })
+
+})
+
+// the nav html
+class Nav extends HTMLElement{
+    constructor(){
+        super()
+
+    }
+    
+
+connectedCallback(){
+    this.innerHTML = `
+    <!-- Start of Nav -->
+    <div class="nav-opener">
+        <div class="nav-icon-line-1"></div>
+        <div class="nav-icon-line-2"></div>
+        <div class="nav-icon-line-3"></div>
+    </div>
+    <nav>
+      <a class="nav-scrimba" href="https://scrimba.com/" rel="noopener" target="_blank"><img class="nav-logo" src="../../../imgs/scrimba-black.svg" alt="scrimba-logo"></a>
+      <div class="nav-other-links">
+        ${ lastSegment.length !== 0 ? `<a href="/" rel="noopener" target="_blank">Home</a>` : ``} 
+        <a target="_blank" rel="noopener" href="https://scrimba.com/learn/weeklychallenge/the-weekly-web-dev-challenge-word-count-latest-challenge-code-to-win-cE62LvsB">Current Challenge</a>  
+        <a href="/hall-of-fame.html" rel="noopener" target="_blank">Hall of Fame</a>
+        <a href="/#prev_challenges">Previous Challenges</a>
+      </div>
+    </nav>    
+    `
+}
+
+}
+
+customElements.define('nav-component', Nav)

--- a/hall-of-fame.html
+++ b/hall-of-fame.html
@@ -13,9 +13,15 @@
 </head>
 
 <body class="gradient">
+    <!-- Start of Nav -->
+    <nav-component>
+        <!-- imported from components/nav.js -->
+    </nav-component>
+    <!-- Endn of Nav  -->
     <div class="page-container">
         <header>
-            <img class="logo" src="../../../imgs/scrimba-black.svg" alt="scrimba-logo">
+            <a href="https://scrimba.com/" rel="noopener" target="_blank" class="home-logo"><img class="logo"
+                src="../../../imgs/scrimba-black.svg" alt="scrimba-logo"></a>
             <h1>The Hall of Fame</h1>
             <h2>Each of these apps was crowned winner of the weekly Web Dev Challenge 🏆🎉</h2>
         </header>
@@ -29,6 +35,7 @@
         <!-- imported from components/footer.js REQUIRES pumpkin.js -->
     </footer-component>
     <!-- End of Footer -->
+    <script type="module" src="components/nav.js" type="text/javascript" defer></script>
     <script type="module" src="components/footer.js" type="text/javascript" defer></script>
     <script type="module" src="displayHallOfFame.js"></script>
     <script type="module" src="pumpkin.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -14,22 +14,11 @@
 
 <body>
   <!-- Start of Nav -->
-  <div class="nav-opener">
-    <div class="nav-icon-line-1"></div>
-    <div class="nav-icon-line-2"></div>
-    <div class="nav-icon-line-3"></div>
-  </div>
-  <nav>
-    <a class="nav-scrimba" href="https://scrimba.com/" rel="noopener" target="_blank"><img class="nav-logo"
-        src="../../../imgs/scrimba-black.svg" alt="scrimba-logo"></a>
-    <div class="nav-other-links">
-      <a target="_blank" rel="noopener"
-        href="https://scrimba.com/learn/weeklychallenge/the-weekly-web-dev-challenge-word-count-latest-challenge-code-to-win-cE62LvsB">Current
-        Challenge</a>
-      <a href="https://weeklywebdevchallenge.scrimba.com/hall-of-fame" rel="noopener" target="_blank">Hall of Fame</a>
-      <a href="#prev_challenges">Previous Challenges</a>
-    </div>
-  </nav>
+  <nav-component>
+        <!-- imported from components/nav.js -->
+  </nav-component>
+  <!-- Endn of Nav  -->
+
 
   <div class="page-container">
     <!-- Start of Header -->
@@ -96,6 +85,7 @@
   </footer-component>
   <!-- End of Footer -->
   <!-- Scripts -->
+  <script type="module" src="components/nav.js" type="text/javascript" defer></script>
   <script type="module" src="components/footer.js" type="text/javascript" defer></script>
   <script type="module" src="index.js" defer></script>
   <script type="module" src="pumpkin.js" defer></script>

--- a/index.js
+++ b/index.js
@@ -31,14 +31,6 @@ import { countdown } from "./challengeCountdown.js";
 //Date Format -> Month day, year time/hour Timezone
 countdown(new Date("October 25, 2021 13:00:00 GMT+01:00"));
 
-// Mobile Nav Opener
-const navOpener = document.querySelector('.nav-opener')
-const nav = document.querySelector('nav')
-
-navOpener.addEventListener('click', () => {
-    nav.classList.toggle('nav-open');
-    navOpener.classList.toggle('exit')
-})
 
 /* Random background color on page load */
 let colorOptions = [


### PR DESCRIPTION
1. Nav component is in `components/nav.js`
2. Have moved the javascript to open mobile nav from `index.js` to `nav.js` else mobile menu only works on `index.html`
3. Have deleted nav elements from `index.html` and `hall-of-fame.html` and imported `nav.js`
4. Have changed scrimba logo in `hall-of-fame.html` header section so it only displays on mobile now the desktop logo is in new nav component. 
5. There was no way to navigate back to the homepage from Hall of Fame so have conditionally added "home" to menu when not on homepage (main Scrimba logo takes user to Scrimba.com main page, not weekly web dev challenge page).

Hope all that's ok else can change!

PS noticed a couple of things that you might already have on your wish list, but just in case you haven't:

1. pumpkin modal displays badly on my laptop screen - the message "pumpkin is proud of you" is offscreen at the bottom - think this is a pretty easy css fix for someone 
2. should the hall of fame page also get random bg color?